### PR TITLE
jetbrains: 2024.2.1 -> 2024.3.3

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -3,66 +3,66 @@
     "aqua": {
       "update-channel": "Aqua RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/aqua/aqua-{version}.tar.gz",
-      "version": "2024.2.1",
-      "sha256": "847b7658843dd06b9d6f2689fa4030e54473b6e5e234f23b6e17a6c646fad07c",
-      "url": "https://jb-proxy-ides.vercel.app/aqua/aqua-2024.2.1.tar.gz",
-      "build_number": "242.22855.128"
+      "version": "2024.3.1",
+      "sha256": "e304d8f900881d18865010819dc035d59be00b1364baa2b98ef47d923907ce57",
+      "url": "https://jb-proxy-ides.vercel.app/aqua/aqua-2024.3.1.tar.gz",
+      "build_number": "243.22562.238"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/cpp/CLion-{version}.tar.gz",
-      "version": "2024.2.3",
-      "sha256": "0afb6e32fe1ceb77ddd07ca7fa7d01a0a5e73a0df42ec58183f9c1a06b84446e",
-      "url": "https://jb-proxy-ides.vercel.app/cpp/CLion-2024.2.3.tar.gz",
-      "build_number": "242.23726.125"
+      "version": "2024.3.1.1",
+      "sha256": "054eff2dcdb7779b97d940b5425ae7c56bfafd657367e3a749275ef6a0a40368",
+      "url": "https://jb-proxy-ides.vercel.app/cpp/CLion-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.225"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "22bce5430534136dc5e63f9e38007f85d2e06b8e96ca42f2403d205dcc171caf",
-      "url": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-2024.3.tar.gz",
-      "build_number": "243.21565.204"
+      "version": "2024.3.3",
+      "sha256": "84158baba8040ea4a6fac4663b9205c410ff7f04d803c2af1e9b4746a6270445",
+      "url": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-2024.3.3.tar.gz",
+      "build_number": "243.23654.19"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/dataspell-{version}.tar.gz",
-      "version": "2024.2.2",
-      "sha256": "9b3dd8185f805d8d968f5a515dbe74d3672e0cd1b2cb052cf81382bd63ddb3b8",
-      "url": "https://jb-proxy-ides.vercel.app/python/dataspell-2024.2.2.tar.gz",
-      "build_number": "242.22855.78"
+      "version": "2024.3.1.1",
+      "sha256": "37e0985cd3bac79cc74962edba726ccdde61101fc4e8876ed060396584332aa3",
+      "url": "https://jb-proxy-ides.vercel.app/python/dataspell-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.236"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "accb6a69d188ec4e9f9a0e850d2e7751cd8aa2cbd4b91d544e5bd2b8342e8b43",
-      "url": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-2024.3.tar.gz",
-      "build_number": "243.21565.196"
+      "version": "2024.3.1.1",
+      "sha256": "625bd0794b535b40926f3fed15b50e1df8ee181acd5a1a8fb174f19cd450cef0",
+      "url": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.252"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/go/goland-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "6d52c50fb665f1d42f1eba8fcfafca0ac4ce101a235ea435558a542ae290a6af",
-      "url": "https://jb-proxy-ides.vercel.app/go/goland-2024.3.tar.gz",
-      "build_number": "243.21565.208"
+      "version": "2024.3.1",
+      "sha256": "028cb0c004c1f0d6e46ce897784ea37291900a85ea49df47678c86aaea1ea681",
+      "url": "https://jb-proxy-ides.vercel.app/go/goland-2024.3.1.tar.gz",
+      "build_number": "243.22562.186"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/ideaIC-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "16d4f411b62ddc7747fe11e8fff004bf8d144df4052b8111306fd4cbba8f748c",
-      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIC-2024.3.tar.gz",
-      "build_number": "243.21565.193"
+      "version": "2024.3.1.1",
+      "sha256": "b183b126de2cd457475eea184874b5da2fa33ba5ae2ff874bdc8c1d534156428",
+      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIC-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.218"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/ideaIU-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "c0627c42510bdd25b82127db62997fe6b7b98cc7e30987a83fa0b419692a15c1",
-      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIU-2024.3.tar.gz",
-      "build_number": "243.21565.193"
+      "version": "2024.3.1.1",
+      "sha256": "d80684aa73fe9dee14ea405058d54a34340266cf675bfbaf4c760da6eb2d3fe9",
+      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIU-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.218"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -75,133 +75,133 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "60e39a14dad77ffa7b2e36f701dc4d5c5bb281231d06d7c292807483a6879071",
-      "url": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-2024.3.tar.gz",
-      "build_number": "243.21565.202",
+      "version": "2024.3.1.1",
+      "sha256": "8bb909b6322f296d4e44265223cffca2649e4344d1233b670f751c5b2d7ae698",
+      "url": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.233",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/pycharm-community-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "266975b832a4b2ec6cf23adc2c244650c1fb546f1ffa36dc2405866f1c32cb3e",
-      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-community-2024.3.tar.gz",
-      "build_number": "243.21565.199"
+      "version": "2024.3.1.1",
+      "sha256": "36b9332262815099d0b86d2689fcf91b379730cb838623d82c0845969bb6470f",
+      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-community-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.220"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "142d7033f0548fd4f3e26bb2f8507f5d16048d9dfbe2f3a3de5246042e269ff7",
-      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-2024.3.tar.gz",
-      "build_number": "243.21565.199"
+      "version": "2024.3.1.1",
+      "sha256": "5698131d93d00a261c720a31ec54ef1c850581c274be6938dd923e8c0383da25",
+      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.220"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "ef9b61c18851b6f3ef2bfa3fe147b34ac191622f65a41f2b53b3a609f9bff360",
-      "url": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-2024.3.tar.gz",
-      "build_number": "243.21565.191"
+      "version": "2024.3.3",
+      "sha256": "3185826c0d85c06bf18c5ece3f5f9698acef006932b7a92b6cb190fd4d8e2807",
+      "url": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-2024.3.3.tar.gz",
+      "build_number": "243.22562.250"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "391ed7fa3f46d672f9d2a9706f21c33f974472cb81ebb172931c6b16c8aa9836",
-      "url": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-2024.3.tar.gz",
-      "build_number": "243.21565.197"
+      "version": "2024.3.1.1",
+      "sha256": "fe849fd90725f12c6dabb20973f1d5eb6fc9baddd692961197527326639d7def",
+      "url": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.213"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-{version}.tar.gz",
-      "version": "2024.2.5",
-      "sha256": "b3ce4f354d4fdbee8dff5d8120db098502f7393fbebe25891f8bd76e51736b69",
-      "url": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-2024.2.5.tar.gz",
-      "build_number": "242.23726.162"
+      "version": "2024.3.2",
+      "sha256": "c6549572baa913c9842b0227257f7477531269393d5989622a3d0b802b999bf8",
+      "url": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-2024.3.2.tar.gz",
+      "build_number": "243.22562.230"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2024.3",
-      "sha256": "23858c20f84a10f3be6ac05cdb03a47e6862fabbf4a748ecef7902f882a9e935",
-      "url": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-2024.3.tar.gz",
-      "build_number": "243.21565.180"
+      "version": "2024.3.1.1",
+      "sha256": "275999ca069658257d6f06875f283abf9c0b102bdf812cf7eefe86a1dda90c1b",
+      "url": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-2024.3.1.1.tar.gz",
+      "build_number": "243.22562.222"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://jb-proxy-ides.vercel.app/writerside/writerside-{version}.tar.gz",
       "version": "2024.3 EAP",
-      "sha256": "651491afd8a42431045b8d6af13954c001aa45f59f905481b1b3b821f140b60b",
-      "url": "https://jb-proxy-ides.vercel.app/writerside/writerside-243.21565.432.tar.gz",
-      "build_number": "243.21565.432"
+      "sha256": "d49e58020d51ec4ccdbdffea5d42b5a2d776a809fc00789cef5abda7b23bd3f6",
+      "url": "https://jb-proxy-ides.vercel.app/writerside/writerside-243.22562.371.tar.gz",
+      "build_number": "243.22562.371"
     }
   },
   "aarch64-linux": {
     "aqua": {
       "update-channel": "Aqua RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/aqua/aqua-{version}-aarch64.tar.gz",
-      "version": "2024.2.1",
-      "sha256": "8136b8a13edc9d7cf35eb0bbac685e74a76b52b0f15541f0289ed0968b316c2c",
-      "url": "https://jb-proxy-ides.vercel.app/aqua/aqua-2024.2.1-aarch64.tar.gz",
-      "build_number": "242.22855.128"
+      "version": "2024.3.1",
+      "sha256": "4895ad44a456f56121cc4e78be45b6a4ccae8080ab7251cd434304465d01f7c4",
+      "url": "https://jb-proxy-ides.vercel.app/aqua/aqua-2024.3.1-aarch64.tar.gz",
+      "build_number": "243.22562.238"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/cpp/CLion-{version}-aarch64.tar.gz",
-      "version": "2024.2.3",
-      "sha256": "be3e6f0d490517c8f6e7c7ac248ab8e8823bf19c8102e7695725f80df6c11d63",
-      "url": "https://jb-proxy-ides.vercel.app/cpp/CLion-2024.2.3-aarch64.tar.gz",
-      "build_number": "242.23726.125"
+      "version": "2024.3.1.1",
+      "sha256": "dacd54a45145ed65b2c40520706432449e4bc3ff2bb23be6cb1fb4c73d9db223",
+      "url": "https://jb-proxy-ides.vercel.app/cpp/CLion-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.225"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "0f923e16f78dda2f86a72921ae9c2ae361950208e32b882a76b7aa3cf560ed6e",
-      "url": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-2024.3-aarch64.tar.gz",
-      "build_number": "243.21565.204"
+      "version": "2024.3.3",
+      "sha256": "b6413cb0855f1beb64b7095f2e21c856e367319440f11ffad787ae88bc80af66",
+      "url": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-2024.3.3-aarch64.tar.gz",
+      "build_number": "243.23654.19"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/dataspell-{version}-aarch64.tar.gz",
-      "version": "2024.2.2",
-      "sha256": "e529c27d3c5eeabec02c7ff2e3c0a682d60b962923054cb9dca2e46bf1ec9104",
-      "url": "https://jb-proxy-ides.vercel.app/python/dataspell-2024.2.2-aarch64.tar.gz",
-      "build_number": "242.22855.78"
+      "version": "2024.3.1.1",
+      "sha256": "31a564e58285a84b226017f18e658684720aa0a615f068447edbe817e6337f76",
+      "url": "https://jb-proxy-ides.vercel.app/python/dataspell-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.236"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "deeba887b6f51c57daef97c7db25578b94bccf5ed777c3867d484d034f60bc12",
-      "url": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-2024.3-aarch64.tar.gz",
-      "build_number": "243.21565.196"
+      "version": "2024.3.1.1",
+      "sha256": "d5481582f8448659a293bc101b9ce2355368c60ab5a18370d4ba09a2eeebf458",
+      "url": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.252"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/go/goland-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "1aeccc1f371bfd07c9b3f09b676af5b63c3032f803aa1aee9b304f6ae07280b3",
-      "url": "https://jb-proxy-ides.vercel.app/go/goland-2024.3-aarch64.tar.gz",
-      "build_number": "243.21565.208"
+      "version": "2024.3.1",
+      "sha256": "9292d1502e3fada094469c590a59465d105fb6c81988f5414dac792ef3ae9dc5",
+      "url": "https://jb-proxy-ides.vercel.app/go/goland-2024.3.1-aarch64.tar.gz",
+      "build_number": "243.22562.186"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/ideaIC-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "7f21a648346c38b9e4c8c0d693b62d2383fc59a5d5228bb12f32549f3b80080a",
-      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIC-2024.3-aarch64.tar.gz",
-      "build_number": "243.21565.193"
+      "version": "2024.3.1.1",
+      "sha256": "8e82e9c1ff8bc561df88d9c6ef3b83498aecdac6f980b9df0cb183bc6dca0c90",
+      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIC-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.218"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/ideaIU-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "8b262ad7dc6efd2ef4b953701771ec6cf526b5e628a1b07afb6092d6e70a55a2",
-      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIU-2024.3-aarch64.tar.gz",
-      "build_number": "243.21565.193"
+      "version": "2024.3.1.1",
+      "sha256": "b3487662edf0904de4bfcd069231068350f7d8e964c0718b88ecbc18a83e5f47",
+      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIU-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.218"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -214,133 +214,133 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "693742e6109a2cbe034ff99a5ebc3932c8a3e9d03aab84df1ea76b74fe29991e",
-      "url": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-2024.3-aarch64.tar.gz",
-      "build_number": "243.21565.202",
+      "version": "2024.3.1.1",
+      "sha256": "d6f0cb476f3a83636b14e7b678d2e0a7f47e060c63bf31a5d645ee7e18adb0fa",
+      "url": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.233",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/pycharm-community-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "1198417e8fc7a7bc789a78939ebcab238c93121e64f706b3f2e6ab31c69fd633",
-      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-community-2024.3-aarch64.tar.gz",
-      "build_number": "243.21565.199"
+      "version": "2024.3.1.1",
+      "sha256": "cbc36953b6943e70468e1908bef9adddc2a9597124e5d794f294095888b0914c",
+      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-community-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.220"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "7394972b57d04d3e1f147a9802661ee6600d6b0213576a551eac9b88939ebd6e",
-      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-2024.3-aarch64.tar.gz",
-      "build_number": "243.21565.199"
+      "version": "2024.3.1.1",
+      "sha256": "a301f7316b17ace60c9e765f50ae0987262e99da3feb222c9abf761fda10cff3",
+      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.220"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "d1b9b3925ad79f50239f11c72f9d4f3ed52716251d54a3340e3aaf63f813d79e",
-      "url": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-2024.3-aarch64.tar.gz",
-      "build_number": "243.21565.191"
+      "version": "2024.3.3",
+      "sha256": "8ca14eeae6a9164da955f9e292dda788bda53a031c24ef6c2fab505e3e2f175b",
+      "url": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-2024.3.3-aarch64.tar.gz",
+      "build_number": "243.22562.250"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "22daedfbc53cb07dd70c504d7e44366c902a17e39cc56bc8121e50db6da28238",
-      "url": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-2024.3-aarch64.tar.gz",
-      "build_number": "243.21565.197"
+      "version": "2024.3.1.1",
+      "sha256": "af3cf7b5e8ac4306a4f5f03bcfc3425aa7ed3aa71f61213d85fd4f5a3d425b75",
+      "url": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.213"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-{version}-aarch64.tar.gz",
-      "version": "2024.2.5",
-      "sha256": "b208af1d63ccdf6411916c087a08830b947fd6d63d86c2b6ceee7394f5538383",
-      "url": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-2024.2.5-aarch64.tar.gz",
-      "build_number": "242.23726.162"
+      "version": "2024.3.2",
+      "sha256": "d5187d7d449d1b1ec6ff2699c0ccdb3c3280841360d3f43c0318a41b865064c8",
+      "url": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-2024.3.2-aarch64.tar.gz",
+      "build_number": "243.22562.230"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-{version}-aarch64.tar.gz",
-      "version": "2024.3",
-      "sha256": "85541c9e8209d7b99422ea2bd1c3b3c14b680f7c5a92cd37f9476c41bfb3c0eb",
-      "url": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-2024.3-aarch64.tar.gz",
-      "build_number": "243.21565.180"
+      "version": "2024.3.1.1",
+      "sha256": "b136ec6696a47511a7396eb5416ff055964a040d72ed29eb6c362e1b37ce0ab5",
+      "url": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-2024.3.1.1-aarch64.tar.gz",
+      "build_number": "243.22562.222"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://jb-proxy-ides.vercel.app/writerside/writerside-{version}-aarch64.tar.gz",
       "version": "2024.3 EAP",
-      "sha256": "c745b284f057bd150b19f773fdfbb4f54922040faaa01293538f51ede9802e35",
-      "url": "https://jb-proxy-ides.vercel.app/writerside/writerside-243.21565.432-aarch64.tar.gz",
-      "build_number": "243.21565.432"
+      "sha256": "6067f6f73c4a178e2d0ae42bd18669045d85b5b5ed2c9115c2488ba7aa2a3d88",
+      "url": "https://jb-proxy-ides.vercel.app/writerside/writerside-243.22562.371-aarch64.tar.gz",
+      "build_number": "243.22562.371"
     }
   },
   "x86_64-darwin": {
     "aqua": {
       "update-channel": "Aqua RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/aqua/aqua-{version}.dmg",
-      "version": "2024.2.1",
-      "sha256": "e65135897e988eb01e2f78e18a92953f592ac0de07c6626780fab544affcd64e",
-      "url": "https://jb-proxy-ides.vercel.app/aqua/aqua-2024.2.1.dmg",
-      "build_number": "242.22855.128"
+      "version": "2024.3.1",
+      "sha256": "2efd04de1b67a394529fb154e63c58e34654af42a5fb12b5989ab8d5a784483b",
+      "url": "https://jb-proxy-ides.vercel.app/aqua/aqua-2024.3.1.dmg",
+      "build_number": "243.22562.238"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/cpp/CLion-{version}.dmg",
-      "version": "2024.2.3",
-      "sha256": "0dfc4d50268e58bb6b3c42c270ea8cca638a8733a5e2e010447cc74d585895e8",
-      "url": "https://jb-proxy-ides.vercel.app/cpp/CLion-2024.2.3.dmg",
-      "build_number": "242.23726.125"
+      "version": "2024.3.1.1",
+      "sha256": "276ae335421b6eddd1d7fbdc27fc826bf7ffa68e32a23f9335ff8be88d89b747",
+      "url": "https://jb-proxy-ides.vercel.app/cpp/CLion-2024.3.1.1.dmg",
+      "build_number": "243.22562.225"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "a0badb24a8cf0d04d7933d3695d5daeaeb296574f1cacaa8fe5ca14329df863f",
-      "url": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-2024.3.dmg",
-      "build_number": "243.21565.204"
+      "version": "2024.3.3",
+      "sha256": "e266609ab3555bbf213edd35f9c0b032dd4c27012334066212b391a5bc972ca4",
+      "url": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-2024.3.3.dmg",
+      "build_number": "243.23654.19"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/dataspell-{version}.dmg",
-      "version": "2024.2.2",
-      "sha256": "2afdedae414e62077580c88c76093ea608b49aa3e4c9c9f1ec8aef7d467a7285",
-      "url": "https://jb-proxy-ides.vercel.app/python/dataspell-2024.2.2.dmg",
-      "build_number": "242.22855.78"
+      "version": "2024.3.1.1",
+      "sha256": "eb5fd54f193f2c94de46c91957a4d36eedce8009cd272c5d8e4fc4763d9dafe3",
+      "url": "https://jb-proxy-ides.vercel.app/python/dataspell-2024.3.1.1.dmg",
+      "build_number": "243.22562.236"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "ea9c1e37afc2a67357755df9c4c12bfaca0106e1d4a6630a5abab9a40a7e8bab",
-      "url": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-2024.3.dmg",
-      "build_number": "243.21565.196"
+      "version": "2024.3.1.1",
+      "sha256": "f31962a284ec68e175d6f5678c0e4fe33c0948514f92673bb7989b38c3622951",
+      "url": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-2024.3.1.1.dmg",
+      "build_number": "243.22562.252"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/go/goland-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "610faf6b940c0271f1c57cac1fb4e52b96aa059b20f7c8439caab380fda0e8b0",
-      "url": "https://jb-proxy-ides.vercel.app/go/goland-2024.3.dmg",
-      "build_number": "243.21565.208"
+      "version": "2024.3.1",
+      "sha256": "ec442f7a42cd95a7956d0ff4eb039f856e99451685a537dda9d67fbcd5b729e6",
+      "url": "https://jb-proxy-ides.vercel.app/go/goland-2024.3.1.dmg",
+      "build_number": "243.22562.186"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/ideaIC-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "9162a57c3f39c2f54b9ab86f41ae25de839e749c1708e674deef59c40c4f577f",
-      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIC-2024.3.dmg",
-      "build_number": "243.21565.193"
+      "version": "2024.3.1.1",
+      "sha256": "505d978a27d0691a7ad8070c005e74bb13862fbb880b75ae924aa4f4558047a0",
+      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIC-2024.3.1.1.dmg",
+      "build_number": "243.22562.218"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/ideaIU-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "73df7fca9085afd81a4564acad598e4196ed003988269205edcf222ef954a0b8",
-      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIU-2024.3.dmg",
-      "build_number": "243.21565.193"
+      "version": "2024.3.1.1",
+      "sha256": "eca0be9cd1d35df6453075dd447c8945d97134b90d1de4313e9b98069d3a39a3",
+      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIU-2024.3.1.1.dmg",
+      "build_number": "243.22562.218"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -353,133 +353,133 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "1383a1fecafa9b84338fef846f434b6deac2849afb4876de544550b86c0c3c01",
-      "url": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-2024.3.dmg",
-      "build_number": "243.21565.202",
+      "version": "2024.3.1.1",
+      "sha256": "30a6f0cffa15034578bd026a80d3faf4469c2123d319a805cc31bfc59f2097a8",
+      "url": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-2024.3.1.1.dmg",
+      "build_number": "243.22562.233",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/pycharm-community-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "25273a4b91cd04ef317988c56a4bd8af8f1c57d184b987571e82621a1e2c7535",
-      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-community-2024.3.dmg",
-      "build_number": "243.21565.199"
+      "version": "2024.3.1.1",
+      "sha256": "72cf007a2f5505544b821c97b34f61f6195f32beaf3bfd032370ee7f03cb5046",
+      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-community-2024.3.1.1.dmg",
+      "build_number": "243.22562.220"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "1678b71fcbdcd3a3125eb008cdf21281168744599de3093b29f8de3fb0bc6e49",
-      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-2024.3.dmg",
-      "build_number": "243.21565.199"
+      "version": "2024.3.1.1",
+      "sha256": "d0329b017d21c25426f625c31fb9e193b9dc0be17150675c1010d3bfd27f2ca2",
+      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-2024.3.1.1.dmg",
+      "build_number": "243.22562.220"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "b8552f7e124b3d7678d6b7dfe3b54b13a70f70c4523f19d36f52172dc276ad3c",
-      "url": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-2024.3.dmg",
-      "build_number": "243.21565.191"
+      "version": "2024.3.3",
+      "sha256": "55e851ef7dcfde75bc8e81a9650577ffa2b3c1fed4f49c529b5bac766e8e734e",
+      "url": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-2024.3.3.dmg",
+      "build_number": "243.22562.250"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "bb6a97f54a1a108f92a88152c1c4af9e6d6b85e66cff4e55038c275b3a061971",
-      "url": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-2024.3.dmg",
-      "build_number": "243.21565.197"
+      "version": "2024.3.1.1",
+      "sha256": "6762f4987be03eb4d6adccc8b9e093598a86c77d341695792c985d9a35b84703",
+      "url": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-2024.3.1.1.dmg",
+      "build_number": "243.22562.213"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-{version}.dmg",
-      "version": "2024.2.5",
-      "sha256": "906bc85ada746fd8e783c4fa524458f6cedde7c77499728da8ccae050201a400",
-      "url": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-2024.2.5.dmg",
-      "build_number": "242.23726.162"
+      "version": "2024.3.2",
+      "sha256": "85ba87fc294d957c3e8efe51633589fd252bc9e6608eb2dbe4b8e5492ef75788",
+      "url": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-2024.3.2.dmg",
+      "build_number": "243.22562.230"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-{version}.dmg",
-      "version": "2024.3",
-      "sha256": "fccac67e93d69ad98a36b0b8c092913fbc8bfc06b1cb7ee3932bad4394f78c78",
-      "url": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-2024.3.dmg",
-      "build_number": "243.21565.180"
+      "version": "2024.3.1.1",
+      "sha256": "cff8b644670fc36aea9f37cd26dbfc1418177b835dd455beb99b8fa483d68063",
+      "url": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-2024.3.1.1.dmg",
+      "build_number": "243.22562.222"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://jb-proxy-ides.vercel.app/writerside/writerside-{version}.dmg",
       "version": "2024.3 EAP",
-      "sha256": "5a44fc83964514916c52b9cd49fa13e3f16757474a84dca85af7c6d97c2ede4b",
-      "url": "https://jb-proxy-ides.vercel.app/writerside/writerside-243.21565.432.dmg",
-      "build_number": "243.21565.432"
+      "sha256": "0c78b8035497c855aea5666256716778abd46dadf68f51e4f91c0db01f62b280",
+      "url": "https://jb-proxy-ides.vercel.app/writerside/writerside-243.22562.371.dmg",
+      "build_number": "243.22562.371"
     }
   },
   "aarch64-darwin": {
     "aqua": {
       "update-channel": "Aqua RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/aqua/aqua-{version}-aarch64.dmg",
-      "version": "2024.2.1",
-      "sha256": "f91c189a05b98e0e0ad0ddc9d08345e80b5cd6b784689b8e75bcbc74cc61d1ff",
-      "url": "https://jb-proxy-ides.vercel.app/aqua/aqua-2024.2.1-aarch64.dmg",
-      "build_number": "242.22855.128"
+      "version": "2024.3.1",
+      "sha256": "ee6ae8231315aff5908d240449be182c9bab58a09ec03bc3afb302b7d7e597d2",
+      "url": "https://jb-proxy-ides.vercel.app/aqua/aqua-2024.3.1-aarch64.dmg",
+      "build_number": "243.22562.238"
     },
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2024.2.3",
-      "sha256": "998d629381e6f596b8e0cf5289fe8ca7cfd3221fc73b6c8548d768889b14196f",
-      "url": "https://jb-proxy-ides.vercel.app/cpp/CLion-2024.2.3-aarch64.dmg",
-      "build_number": "242.23726.125"
+      "version": "2024.3.1.1",
+      "sha256": "57d7040f197dc1859ab16636bbb7006acc542eb15d1892692e78dc205bae2502",
+      "url": "https://jb-proxy-ides.vercel.app/cpp/CLion-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.225"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "94efff741478dbe1d33726238b9d6f04b0269761ed0f787eaa93b50ae40c6704",
-      "url": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-2024.3-aarch64.dmg",
-      "build_number": "243.21565.204"
+      "version": "2024.3.3",
+      "sha256": "56a31779b85e53da711a47bf3a6b801e7dd7565057f5feceb67fa456350f7830",
+      "url": "https://jb-proxy-ides.vercel.app/datagrip/datagrip-2024.3.3-aarch64.dmg",
+      "build_number": "243.23654.19"
     },
     "dataspell": {
       "update-channel": "DataSpell RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/dataspell-{version}-aarch64.dmg",
-      "version": "2024.2.2",
-      "sha256": "3d153a2813dd5b1527a0e5c429a390cdcb7d921774c369818283a6706bb47375",
-      "url": "https://jb-proxy-ides.vercel.app/python/dataspell-2024.2.2-aarch64.dmg",
-      "build_number": "242.22855.78"
+      "version": "2024.3.1.1",
+      "sha256": "cd2d146b54036d657b68343efb9c5f7cf234353f5ffdc9af85e05f63dbf7777c",
+      "url": "https://jb-proxy-ides.vercel.app/python/dataspell-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.236"
     },
     "gateway": {
       "update-channel": "Gateway RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "e2ad82e41258e108fd6844a182148db036f8211dc5f69e13de899f529c0345df",
-      "url": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-2024.3-aarch64.dmg",
-      "build_number": "243.21565.196"
+      "version": "2024.3.1.1",
+      "sha256": "f4ff084d4054f75d3b10110b2abaddecbac30204d80c39dcb7a5925f2278c41a",
+      "url": "https://jb-proxy-ides.vercel.app/idea/gateway/JetBrainsGateway-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.252"
     },
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/go/goland-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "052f0c50c100b751ece65276ae284952a2470b2769c05b578b99d0dce1dae542",
-      "url": "https://jb-proxy-ides.vercel.app/go/goland-2024.3-aarch64.dmg",
-      "build_number": "243.21565.208"
+      "version": "2024.3.1",
+      "sha256": "4805e527a7d0cb66c278fcdba70468e14854defc3619edad439763d355303eba",
+      "url": "https://jb-proxy-ides.vercel.app/go/goland-2024.3.1-aarch64.dmg",
+      "build_number": "243.22562.186"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/ideaIC-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "568e0a3a1d623627411abed770ce20c2a9906331335e4576c72f019a1e992267",
-      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIC-2024.3-aarch64.dmg",
-      "build_number": "243.21565.193"
+      "version": "2024.3.1.1",
+      "sha256": "ea8c050308c46e276055193d882daa6d965f33256a447c05d5ad9f22b54e5d14",
+      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIC-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.218"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/idea/ideaIU-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "022d1dbbf6798d6e5b6392b7b11ad782b6590a34dfae30ea3564bc131a70e526",
-      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIU-2024.3-aarch64.dmg",
-      "build_number": "243.21565.193"
+      "version": "2024.3.1.1",
+      "sha256": "308773c0f5d15754fbdf1bbaf2155e34b8808880afdee55e5ac8bad8d477162d",
+      "url": "https://jb-proxy-ides.vercel.app/idea/ideaIU-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.218"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -492,67 +492,67 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "95ed8e4ad4f94a159beec0306135b6bb85e0045d6afe3e4c2364d90901ae39b5",
-      "url": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-2024.3-aarch64.dmg",
-      "build_number": "243.21565.202",
+      "version": "2024.3.1.1",
+      "sha256": "8d9a3251fea4611c8b90d010571965993836ff1738bc55c2c3692f37f6169eed",
+      "url": "https://jb-proxy-ides.vercel.app/webide/PhpStorm-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.233",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/pycharm-community-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "eb393d0ad5414a01ab8d2b00538a57f1170e662685d7e3c1e7d25b4ac4de04bd",
-      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-community-2024.3-aarch64.dmg",
-      "build_number": "243.21565.199"
+      "version": "2024.3.1.1",
+      "sha256": "ad894fdd3f56260afde718bf8f8dd342780e5a5ecfdbf3c66772a4e1562376fe",
+      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-community-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.220"
     },
     "pycharm-professional": {
       "update-channel": "PyCharm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "254243b532bcbe60b36fba2900048ab5eb6e5edb0aeb45945a63fade3929ebc8",
-      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-2024.3-aarch64.dmg",
-      "build_number": "243.21565.199"
+      "version": "2024.3.1.1",
+      "sha256": "b2afcf6bb9a9a2fb6c516815ce08073429ea506f44c7cafa9503c59da310caae",
+      "url": "https://jb-proxy-ides.vercel.app/python/pycharm-professional-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.220"
     },
     "rider": {
       "update-channel": "Rider RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "2ca76a1d37bd429c8cfd8792512ecd6a9ff385c152e65c68a4620c8a67441e44",
-      "url": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-2024.3-aarch64.dmg",
-      "build_number": "243.21565.191"
+      "version": "2024.3.3",
+      "sha256": "139f8444b48c89745216616bc7a263259a95105892233651fb08b14cc18953a1",
+      "url": "https://jb-proxy-ides.vercel.app/rider/JetBrains.Rider-2024.3.3-aarch64.dmg",
+      "build_number": "243.22562.250"
     },
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "410f621c351b57b6fdc15391f836f45a454f2accee8d49fd60848ced3ddd4c25",
-      "url": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-2024.3-aarch64.dmg",
-      "build_number": "243.21565.197"
+      "version": "2024.3.1.1",
+      "sha256": "1e96dcbaf0b6d6821de44f394a671780b21e88fbb05a3cf67d90fcfb9dcbc559",
+      "url": "https://jb-proxy-ides.vercel.app/ruby/RubyMine-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.213"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-{version}-aarch64.dmg",
-      "version": "2024.2.5",
-      "sha256": "f0ccd53e5cd8a0a143db956fbc6d118d3771bc42c62b846e9d396a620bea79d1",
-      "url": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-2024.2.5-aarch64.dmg",
-      "build_number": "242.23726.162"
+      "version": "2024.3.2",
+      "sha256": "2d715c9a4137815a45abcd208121ef5d66f2b89d3f041d5e905e45c487834985",
+      "url": "https://jb-proxy-ides.vercel.app/rustrover/RustRover-2024.3.2-aarch64.dmg",
+      "build_number": "243.22562.230"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2024.3",
-      "sha256": "b3fed87c00746694419b0da71baf71ebb10a8c3803c5a1502c689ff9ce7831f4",
-      "url": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-2024.3-aarch64.dmg",
-      "build_number": "243.21565.180"
+      "version": "2024.3.1.1",
+      "sha256": "afa44c3603ecdf093ab701b19e6bfc5379a45f27c0df54a507d48c20b7941bb8",
+      "url": "https://jb-proxy-ides.vercel.app/webstorm/WebStorm-2024.3.1.1-aarch64.dmg",
+      "build_number": "243.22562.222"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
       "url-template": "https://jb-proxy-ides.vercel.app/writerside/writerside-{version}-aarch64.dmg",
       "version": "2024.3 EAP",
-      "sha256": "04996f17dfb4a840c74270266efc4dad9b78fa498fb9016109d1b58b498791b5",
-      "url": "https://jb-proxy-ides.vercel.app/writerside/writerside-243.21565.432-aarch64.dmg",
-      "build_number": "243.21565.432"
+      "sha256": "9d86ef50b4c6d2a07d236219e9b05c0557241fb017d52ac395719bdb425130f5",
+      "url": "https://jb-proxy-ides.vercel.app/writerside/writerside-243.22562.371-aarch64.dmg",
+      "build_number": "243.22562.371"
     }
   }
 }


### PR DESCRIPTION
jetbrains.aqua: 2024.2.1 -> 2024.3.1
jetbrains.clion: 2024.2.3 -> 2024.3.1.1
jetbrains.datagrip: 2024.3 -> 2024.3.3
jetbrains.dataspell: 2024.2.2 -> 2024.3.1.1
jetbrains.gateway: 2024.3 -> 2024.3.1.1
jetbrains.goland: 2024.3 -> 2024.3.1
jetbrains.idea-community: 2024.3 -> 2024.3.1.1
jetbrains.idea-ultimate: 2024.3 -> 2024.3.1.1
jetbrains.phpstorm: 2024.3 -> 2024.3.1.1
jetbrains.pycharm-community: 2024.3 -> 2024.3.1.1
jetbrains.pycharm-professional: 2024.3 -> 2024.3.1.1
jetbrains.rider: 2024.3 -> 2024.3.3
jetbrains.ruby-mine: 2024.3 -> 2024.3.1.1
jetbrains.rust-rover: 2024.2.5 -> 2024.3.2
jetbrains.webstorm: 2024.3 -> 2024.3.1.1
jetbrains.writerside: 2024.3 EAP -> 2024.3 EAP


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
